### PR TITLE
feat(import): support assignee mapping from markdown

### DIFF
--- a/src/thought/client.py
+++ b/src/thought/client.py
@@ -34,3 +34,50 @@ class NotionAPIClient:
         if token is None:
             raise ValueError("Notion access token is required")
         return NotionClient(auth=token)
+
+    def search_users(self, search_term: str | None = None) -> list[dict[str, Any]]:
+        """
+        Search for users in the workspace
+        """
+        assert self.client is not None
+        users = self.client.users.list()
+        all_users = users.get("results", [])
+
+        if search_term is None:
+            return all_users
+
+        search_lower = search_term.lower()
+        filtered_users = []
+
+        for user in all_users:
+            name = user.get("name", "").lower()
+            email = (
+                user.get("person", {}).get("email", "").lower()
+                if user.get("person")
+                else ""
+            )
+
+            if search_lower in name or search_lower in email:
+                filtered_users.append(user)
+
+        return filtered_users
+
+    def get_user_by_name_or_email(self, identifier: str) -> dict[str, Any] | None:
+        """
+        Get a user by name or email
+        """
+        users = self.search_users(identifier)
+
+        for user in users:
+            name = user.get("name", "").lower()
+            email = (
+                user.get("person", {}).get("email", "").lower()
+                if user.get("person")
+                else ""
+            )
+            identifier_lower = identifier.lower()
+
+            if identifier_lower in (name, email):
+                return user
+
+        return None

--- a/src/thought/markdown_parser.py
+++ b/src/thought/markdown_parser.py
@@ -57,6 +57,11 @@ class ParsedMarkdown:
             "notion_page_id"
         )
 
+    @property
+    def assignee(self) -> str | None:
+        """Extract assignee from frontmatter."""
+        return self.frontmatter.get("assignee") or self.frontmatter.get("assigned_to")
+
 
 class MarkdownParser:
     """Parser for Markdown files with frontmatter support."""

--- a/src/thought/services/markdown_import.py
+++ b/src/thought/services/markdown_import.py
@@ -207,7 +207,7 @@ class MarkdownImportService(GenericService):
         properties = {}
         db_prop_names_lower = {name.lower(): name for name in db_properties.keys()}
 
-        for key, value in frontmatter.items():
+        for key, original_value in frontmatter.items():
             # Skip special keys
             if key in {"notion_id", "notion_page_id"}:
                 continue
@@ -228,6 +228,16 @@ class MarkdownImportService(GenericService):
             # Get property type from database schema
             prop_config = db_properties[actual_prop_name]
             prop_type = prop_config.get("type", "")
+
+            # Set the working value
+            value = original_value
+
+            # Special handling for assignee fields
+            if key.lower() in ["assignee", "assigned_to"] and prop_type == "people":
+                resolved_value = self._resolve_assignee_to_user_id(original_value)
+                if not resolved_value:
+                    continue  # Skip if user not found
+                value = resolved_value
 
             # Convert value based on property type
             if prop_type == "select":
@@ -259,9 +269,51 @@ class MarkdownImportService(GenericService):
                 properties[actual_prop_name] = {
                     prop_type: [{"text": {"content": str(value)}}]
                 }
+            elif prop_type == "people":
+                # Handle people/user assignments - value should be user ID(s)
+                if isinstance(value, list):
+                    # Multiple assignees
+                    properties[actual_prop_name] = {
+                        "people": [
+                            {"object": "user", "id": str(user_id)}
+                            for user_id in value
+                            if user_id
+                        ]
+                    }
+                # Single assignee
+                elif value:
+                    properties[actual_prop_name] = {
+                        "people": [{"object": "user", "id": str(value)}]
+                    }
             # Add more property types as needed
 
         return properties
+
+    def _resolve_assignee_to_user_id(
+        self, assignee_value: Any
+    ) -> str | list[str] | None:
+        """Resolve assignee name/email to Notion user ID(s)."""
+        if not assignee_value:
+            return None
+
+        if isinstance(assignee_value, list):
+            # Multiple assignees
+            user_ids = []
+            for assignee in assignee_value:
+                user = self.client.get_user_by_name_or_email(str(assignee))
+                if user:
+                    user_ids.append(user["id"])
+                else:
+                    print(f"Warning: User '{assignee}' not found in workspace")
+            return user_ids if user_ids else None
+        else:
+            # Single assignee
+            user = self.client.get_user_by_name_or_email(str(assignee_value))
+            if user:
+                return user["id"]
+            else:
+                print(f"Warning: User '{assignee_value}' not found in workspace")
+                return None
 
     def _create_page(self, database_id: str, parsed: ParsedMarkdown) -> str:
         """Create a new page in Notion."""

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -12,6 +12,8 @@ class TestNotionAPIClient:
     Note: these are not integration tests using this API client
     """
 
+    EXPECTED_USER_COUNT = 2
+
     @staticmethod
     @patch("thought.client.NOTION_ACCESS_TOKEN", "mocked_token")
     @patch("thought.client.NotionClient")
@@ -173,3 +175,96 @@ class TestNotionAPIClient:
 
         with pytest.raises(AssertionError):
             client.query(test_query)
+
+    @staticmethod
+    @patch("thought.client.NOTION_ACCESS_TOKEN", "mocked_token")
+    @patch("thought.client.NotionClient")
+    def test_search_users(mock_notion_client):
+        """
+        Test searching for users in the workspace
+        """
+        # Setup mock
+        mock_client_instance = MagicMock()
+        mock_notion_client.return_value = mock_client_instance
+        mock_client_instance.users.list.return_value = {
+            "results": [
+                {
+                    "id": "user1",
+                    "name": "John Doe",
+                    "type": "person",
+                    "person": {"email": "john@example.com"},
+                },
+                {
+                    "id": "user2",
+                    "name": "Jane Smith",
+                    "type": "person",
+                    "person": {"email": "jane@example.com"},
+                },
+            ]
+        }
+
+        # Create client and test search
+        client = NotionAPIClient()
+
+        # Test search with no filter
+        all_users = client.search_users()
+        assert len(all_users) == TestNotionAPIClient.EXPECTED_USER_COUNT
+
+        # Test search with name filter
+        john_users = client.search_users("john")
+        assert len(john_users) == 1
+        assert john_users[0]["name"] == "John Doe"
+
+        # Test search with email filter
+        jane_users = client.search_users("jane@example.com")
+        assert len(jane_users) == 1
+        assert jane_users[0]["name"] == "Jane Smith"
+
+    @staticmethod
+    @patch("thought.client.NOTION_ACCESS_TOKEN", "mocked_token")
+    @patch("thought.client.NotionClient")
+    def test_get_user_by_name_or_email(mock_notion_client):
+        """
+        Test getting a specific user by name or email
+        """
+        # Setup mock
+        mock_client_instance = MagicMock()
+        mock_notion_client.return_value = mock_client_instance
+        mock_client_instance.users.list.return_value = {
+            "results": [
+                {
+                    "id": "user1",
+                    "name": "John Doe",
+                    "type": "person",
+                    "person": {"email": "john@example.com"},
+                },
+                {
+                    "id": "user2",
+                    "name": "Jane Smith",
+                    "type": "person",
+                    "person": {"email": "jane@example.com"},
+                },
+            ]
+        }
+
+        # Create client and test user lookup
+        client = NotionAPIClient()
+
+        # Test lookup by exact name
+        user = client.get_user_by_name_or_email("John Doe")
+        assert user is not None
+        assert user["id"] == "user1"
+
+        # Test lookup by exact email
+        user = client.get_user_by_name_or_email("jane@example.com")
+        assert user is not None
+        assert user["id"] == "user2"
+
+        # Test lookup with case-insensitive match
+        user = client.get_user_by_name_or_email("JOHN DOE")
+        assert user is not None
+        assert user["id"] == "user1"
+
+        # Test lookup with non-existent user
+        user = client.get_user_by_name_or_email("Unknown User")
+        assert user is None

--- a/tests/test_markdown_parser.py
+++ b/tests/test_markdown_parser.py
@@ -193,6 +193,35 @@ title: No ID
         result3 = parser.parse_content(content3)
         assert result3.notion_id is None
 
+    def test_assignee_property(self, parser):
+        """Test assignee extraction."""
+        # assignee field
+        content1 = """---
+assignee: john@example.com
+---
+# Title
+"""
+        result1 = parser.parse_content(content1)
+        assert result1.assignee == "john@example.com"
+
+        # assigned_to field
+        content2 = """---
+assigned_to: Jane Doe
+---
+# Title
+"""
+        result2 = parser.parse_content(content2)
+        assert result2.assignee == "Jane Doe"
+
+        # No assignee
+        content3 = """---
+title: No Assignee
+---
+# Title
+"""
+        result3 = parser.parse_content(content3)
+        assert result3.assignee is None
+
     def test_validate_markdown(self, parser):
         """Test Markdown validation."""
         # Valid Markdown


### PR DESCRIPTION
- Add user search and lookup by name/email to the API client.
- Parse assignee fields from markdown frontmatter (`assignee`, `assigned_to`).
- Resolve assignee names/emails to Notion user IDs when importing.
- Extend import logic to handle people property assignments.
- Add tests for assignee extraction and user lookup.
