### PR TITLE
fix(markdown-import): fix broken unmappable property detection

### DIFF
--- a/src/thought/services/markdown_import.py
+++ b/src/thought/services/markdown_import.py
@@ -490,25 +490,48 @@ class MarkdownImportService(GenericService):
         except Exception as e:
             return False, [f"Failed to retrieve database: {e!s}"]
 
-        # Parse sample files to get property names
+        # Parse sample files to get property names that would actually be used
         all_properties = set()
         for file_path in sample_files[:5]:  # Check up to 5 files
             try:
                 parsed = self.parser.parse_file(file_path)
-                properties = self.converter.frontmatter_to_properties(
-                    parsed.frontmatter
+                # Use the same logic as the actual import process
+                properties = self._convert_properties_with_schema(
+                    parsed.frontmatter, db_properties
                 )
                 all_properties.update(properties.keys())
             except Exception:
                 continue
 
-        # Check for missing properties
-        db_prop_names = {name for name in db_properties.keys()}
-        missing_props = all_properties - db_prop_names
+        # Find properties that are in frontmatter but not mappable to database
+        all_frontmatter_keys = set()
+        for file_path in sample_files[:5]:  # Check up to 5 files
+            try:
+                parsed = self.parser.parse_file(file_path)
+                all_frontmatter_keys.update(parsed.frontmatter.keys())
+            except Exception:
+                continue
 
-        if missing_props:
+        # Check for frontmatter properties that won't be imported
+        db_prop_names_lower = {name.lower() for name in db_properties.keys()}
+        unmappable_props = []
+
+        for key in all_frontmatter_keys:
+            # Skip special keys and title (title is always handled automatically)
+            if key in {"notion_id", "notion_page_id", "title"}:
+                continue
+
+            # Check if this property can be mapped to a database property
+            property_name = key.replace("_", " ").title()
+            if (
+                property_name not in db_properties
+                and property_name.lower() not in db_prop_names_lower
+            ):
+                unmappable_props.append(key)
+
+        if unmappable_props:
             warnings.append(
-                f"Database missing properties: {', '.join(missing_props)}. "
+                f"Database missing properties: {', '.join(unmappable_props)}. "
                 "These will be skipped during import."
             )
 

--- a/tests/test_markdown_import.py
+++ b/tests/test_markdown_import.py
@@ -389,11 +389,16 @@ custom_field: Value
             file_path=test_file,
         )
 
-        # Configure converter to return properties
+        # Configure converter to return properties (still needed for backward compatibility)
         import_service.converter.frontmatter_to_properties.return_value = {
             "Title": {"rich_text": [{"text": {"content": "Test"}}]},
             "Custom Field": {"rich_text": [{"text": {"content": "Value"}}]},
         }
+
+        # Mock the _convert_properties_with_schema method used in validation
+        import_service._convert_properties_with_schema = MagicMock(
+            return_value={"Title": {"title": [{"text": {"content": "Test"}}]}}
+        )
 
         # Mock database schema
         import_service.client.client.databases.retrieve = MagicMock(
@@ -411,7 +416,7 @@ custom_field: Value
 
         assert valid
         assert len(warnings) > 0
-        assert "Custom Field" in warnings[0]
+        assert "custom_field" in warnings[0]
 
     def test_mode_replace(self, import_service, sample_parsed_markdown):
         """Test replace mode for updates."""


### PR DESCRIPTION
- Enhance validation to warn about frontmatter keys not mappable to database properties, matching actual import logic.
- Exclude special keys and auto-handled title from warnings.
- Update related test to expect original frontmatter key formatting.
