### PR TITLE
feat(import): support project relation and user assignment

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,7 @@ Thought is a Notion CLI tool built with Python that provides database management
 ## Development Commands
 
 ### Testing
+
 ```bash
 # Run all tests with coverage
 pytest
@@ -21,6 +22,7 @@ pytest -v
 ```
 
 ### Code Quality
+
 ```bash
 # Check code with ruff linter
 ruff check .
@@ -33,6 +35,7 @@ pre-commit run --all-files
 ```
 
 ### Installation & Setup
+
 ```bash
 # Install in development mode
 uv pip install -e ".[dev]"
@@ -42,6 +45,7 @@ uv pip install -e .
 ```
 
 ### CLI Usage
+
 ```bash
 # Main CLI entry point
 thought --help
@@ -98,6 +102,7 @@ thought import ./docs/ --database "https://notion.so/your-database-url" --dry-ru
 ### Service Integration
 
 Services are registered in `settings.SERVICES_REGISTERED` and must:
+
 - Inherit from `GenericService` or `APIService`
 - Implement required methods (e.g., `authorize()` for API services)
 - Be placed in `src/thought/services/` directory
@@ -106,13 +111,15 @@ Services are registered in `settings.SERVICES_REGISTERED` and must:
 ### Environment Variables
 
 Required for operation:
+
 - `NOTION_ACCESS_TOKEN`: Notion integration token
 - `INSTAPAPER_CONSUMER_ID`, `INSTAPAPER_CONSUMER_SECRET`: For Instapaper sync
 - `INSTAPAPER_USER`, `INSTAPAPER_PASS`: Instapaper credentials
 
-## Testing
+## Testing Environment
 
 Uses pytest with fixtures defined in `conftest.py`. Key test patterns:
+
 - `notion_api_client` fixture provides NotionAPIClient instance
 - Tests focus on client initialization and API interaction
 - Coverage reporting enabled with `--cov=thought`
@@ -124,3 +131,8 @@ Uses pytest with fixtures defined in `conftest.py`. Key test patterns:
 - Double quotes for strings
 - Space indentation
 - Pre-commit hooks enforce quality standards
+
+## Development Workflow
+
+- Memory reminders:
+  - Make sure to always update the README.md at the end of building a new feature

--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ export INSTAPAPER_PASS="your_password"
   * Multiple merge strategies (merge, replace, skip)
   * Dry-run mode for previewing changes
   * Full Markdown syntax support with rich text formatting
+  * Project linking via relation properties
+  * Automatic user assignment resolution
 
 * **Service Integration**
   * Sync data from Instapaper to Notion collections
@@ -147,6 +149,8 @@ tags:
 priority: 5
 completed: false
 due_date: 2024-12-31
+assignee: john@example.com
+project: Website Redesign
 notion_id: optional-page-id-for-updates
 ---
 
@@ -159,6 +163,7 @@ Content with **bold**, *italic*, `code`, and [links](https://example.com).
 - Bullet lists
 - Code blocks with syntax highlighting
 - Tables and quotes
+- [ ] Checkboxes that convert to Notion to-do blocks
 ```
 
 #### Import Options
@@ -174,6 +179,35 @@ Content with **bold**, *italic*, `code`, and [links](https://example.com).
   * `id`: Match by notion_id in frontmatter
   * `title`: Match by title
 * **--dry-run**: Preview changes without applying them
+
+#### Special Property Handling
+
+The import feature automatically handles certain property types with special processing:
+
+##### User Assignment (People Properties)
+When your database has a "people" property type and your frontmatter includes `assignee` or `assigned_to`:
+- The tool automatically looks up users by name or email
+- Supports single assignee: `assignee: john@example.com`
+- Supports multiple assignees: `assignee: ["john@example.com", "jane@example.com"]`
+- Users not found in the workspace are skipped with a warning
+
+##### Project Linking (Relation Properties)
+When your database has a "relation" property type and your frontmatter includes `project` or `projects`:
+- The tool automatically searches for matching pages/databases by name
+- Supports single project: `project: Website Redesign`
+- Supports multiple projects: `projects: ["Project Alpha", "Project Beta"]`
+- Uses case-insensitive matching with exact match preference
+- Projects not found are skipped with a warning
+
+##### Property Type Conversions
+The tool automatically converts frontmatter values to appropriate Notion property types:
+- **Text/Title**: String values → Rich text
+- **Number**: Numeric values → Number property
+- **Checkbox**: Boolean values → Checkbox property
+- **Select/Status**: String values → Select/Status options
+- **Multi-select**: Arrays → Multi-select options
+- **Date**: Date strings → Date property
+- **Tags**: Arrays → Multi-select (if property name is "Tags")
 
 ### Service Integration
 
@@ -311,6 +345,22 @@ thought import ./docs --database "..." --recursive
 ```bash
 # Update by ID with content replacement
 thought import ticket.md --database "..." --identifier id --mode replace
+```
+
+#### Import tickets with project assignments
+
+```bash
+# Import tickets that link to projects via relation properties
+thought import tickets/ --database "..." --recursive
+
+# Example ticket frontmatter:
+# ---
+# title: Fix authentication bug
+# status: In Progress
+# assignee: developer@company.com
+# project: Website Redesign
+# tags: [bug, high-priority]
+# ---
 ```
 
 #### Import with specific properties only

--- a/src/thought/client.py
+++ b/src/thought/client.py
@@ -185,3 +185,127 @@ class NotionAPIClient:
 
         self.logger.warning(f"User not found | identifier={identifier}")
         return None
+
+    def search_pages(
+        self, query: str | None = None, filter_type: str | None = None
+    ) -> list[dict[str, Any]]:
+        """
+        Search for pages and databases in the workspace
+
+        Args:
+            query: Text to search for in page/database titles
+            filter_type: Optional filter - "page" or "database"
+
+        Returns:
+            List of pages/databases matching the search criteria
+        """
+        assert self.client is not None
+
+        start_time = time.time()
+
+        try:
+            search_params: dict[str, Any] = {}
+            if query:
+                search_params["query"] = query
+            if filter_type:
+                search_params["filter"] = {"value": filter_type, "property": "object"}
+
+            self.logger.debug(
+                f"Searching pages/databases | query={query} | filter={filter_type}"
+            )
+
+            response = self.client.search(**search_params)
+            results = response.get("results", [])
+
+            duration = time.time() - start_time
+            self.logger.info(
+                f"Search completed | query={query} | filter={filter_type} | "
+                f"results={len(results)} | duration={duration:.3f}s"
+            )
+            log_api_call(
+                self.logger,
+                "POST",
+                "search",
+                params=search_params,
+                response_status=200,
+                duration=duration,
+            )
+
+            return results
+
+        except Exception as e:
+            duration = time.time() - start_time
+            self.logger.error(
+                f"Search failed | query={query} | filter={filter_type} | "
+                f"error={e} | duration={duration:.3f}s"
+            )
+            log_api_call(
+                self.logger,
+                "POST",
+                "search",
+                params={"query": query, "filter": filter_type},
+                response_status=None,
+                duration=duration,
+            )
+            raise
+
+    def _extract_title_text(self, result: dict[str, Any]) -> str:
+        """Extract title text from a Notion result object."""
+        properties = result.get("properties", {})
+
+        # Find title property
+        title_prop = None
+        for _prop_name, prop_value in properties.items():
+            if prop_value.get("type") == "title":
+                title_prop = prop_value
+                break
+
+        if not title_prop or not title_prop.get("title"):
+            return ""
+
+        # Extract text content
+        title_text = ""
+        for text_block in title_prop["title"]:
+            if text_block.get("type") == "text":
+                title_text += text_block.get("text", {}).get("content", "")
+
+        return title_text
+
+    def find_project_by_name(self, project_name: str) -> dict[str, Any] | None:
+        """
+        Find a project (page or database) by its name/title
+
+        Args:
+            project_name: The name of the project to find
+
+        Returns:
+            The first matching page/database or None if not found
+        """
+        self.logger.debug(f"Looking for project | name={project_name}")
+
+        # Search for pages and databases with the project name
+        results = self.search_pages(query=project_name)
+        project_name_lower = project_name.lower()
+
+        # Try exact match first (case-insensitive)
+        for result in results:
+            title_text = self._extract_title_text(result)
+            if title_text.lower() == project_name_lower:
+                self.logger.debug(
+                    f"Project found (exact match) | name={project_name} | "
+                    f"id={result.get('id')} | type={result.get('object')}"
+                )
+                return result
+
+        # If no exact match, try partial match
+        for result in results:
+            title_text = self._extract_title_text(result)
+            if project_name_lower in title_text.lower():
+                self.logger.debug(
+                    f"Project found (partial match) | name={project_name} | "
+                    f"id={result.get('id')} | type={result.get('object')}"
+                )
+                return result
+
+        self.logger.warning(f"Project not found | name={project_name}")
+        return None

--- a/src/thought/services/markdown_import.py
+++ b/src/thought/services/markdown_import.py
@@ -333,7 +333,70 @@ class MarkdownImportService(GenericService):
 
         return valid_properties
 
-    def _convert_properties_with_schema(  # noqa: PLR0912
+    def _convert_property_value(  # noqa: PLR0911, PLR0912
+        self, prop_type: str, value: Any, actual_prop_name: str
+    ) -> dict[str, Any] | None:
+        """Convert a single property value based on its type."""
+        if prop_type == "select":
+            return {actual_prop_name: {"select": {"name": str(value)}}}
+        elif prop_type == "status":
+            return {actual_prop_name: {"status": {"name": str(value)}}}
+        elif prop_type == "multi_select":
+            if isinstance(value, list):
+                return {
+                    actual_prop_name: {
+                        "multi_select": [{"name": str(item)} for item in value]
+                    }
+                }
+            else:
+                return {actual_prop_name: {"multi_select": [{"name": str(value)}]}}
+        elif prop_type == "checkbox":
+            return {actual_prop_name: {"checkbox": bool(value)}}
+        elif prop_type == "number":
+            return {actual_prop_name: {"number": float(value) if value else None}}
+        elif prop_type == "date":
+            if isinstance(value, str):
+                return {actual_prop_name: {"date": {"start": value}}}
+            else:
+                # Handle datetime objects from frontmatter
+                return {actual_prop_name: {"date": {"start": str(value)}}}
+        elif prop_type in ["title", "rich_text"]:
+            return {actual_prop_name: {prop_type: [{"text": {"content": str(value)}}]}}
+        elif prop_type == "people":
+            # Handle people/user assignments - value should be user ID(s)
+            if isinstance(value, list):
+                # Multiple assignees
+                return {
+                    actual_prop_name: {
+                        "people": [
+                            {"object": "user", "id": str(user_id)}
+                            for user_id in value
+                            if user_id
+                        ]
+                    }
+                }
+            # Single assignee
+            elif value:
+                return {
+                    actual_prop_name: {"people": [{"object": "user", "id": str(value)}]}
+                }
+        elif prop_type == "relation":
+            # Handle relation properties - value should be page ID(s)
+            if isinstance(value, list):
+                # Multiple related pages
+                return {
+                    actual_prop_name: {
+                        "relation": [
+                            {"id": str(page_id)} for page_id in value if page_id
+                        ]
+                    }
+                }
+            # Single related page
+            elif value:
+                return {actual_prop_name: {"relation": [{"id": str(value)}]}}
+        return None
+
+    def _convert_properties_with_schema(
         self, frontmatter: dict[str, Any], db_properties: dict[str, dict[str, Any]]
     ) -> dict[str, Any]:
         """Convert frontmatter to Notion properties using database schema."""
@@ -372,53 +435,17 @@ class MarkdownImportService(GenericService):
                     continue  # Skip if user not found
                 value = resolved_value
 
+            # Special handling for project fields
+            if key.lower() in ["project", "projects"] and prop_type == "relation":
+                resolved_value = self._resolve_project_to_page_id(original_value)
+                if not resolved_value:
+                    continue  # Skip if project not found
+                value = resolved_value
+
             # Convert value based on property type
-            if prop_type == "select":
-                properties[actual_prop_name] = {"select": {"name": str(value)}}
-            elif prop_type == "status":
-                properties[actual_prop_name] = {"status": {"name": str(value)}}
-            elif prop_type == "multi_select":
-                if isinstance(value, list):
-                    properties[actual_prop_name] = {
-                        "multi_select": [{"name": str(item)} for item in value]
-                    }
-                else:
-                    properties[actual_prop_name] = {
-                        "multi_select": [{"name": str(value)}]
-                    }
-            elif prop_type == "checkbox":
-                properties[actual_prop_name] = {"checkbox": bool(value)}
-            elif prop_type == "number":
-                properties[actual_prop_name] = {
-                    "number": float(value) if value else None
-                }
-            elif prop_type == "date":
-                if isinstance(value, str):
-                    properties[actual_prop_name] = {"date": {"start": value}}
-                else:
-                    # Handle datetime objects from frontmatter
-                    properties[actual_prop_name] = {"date": {"start": str(value)}}
-            elif prop_type in ["title", "rich_text"]:
-                properties[actual_prop_name] = {
-                    prop_type: [{"text": {"content": str(value)}}]
-                }
-            elif prop_type == "people":
-                # Handle people/user assignments - value should be user ID(s)
-                if isinstance(value, list):
-                    # Multiple assignees
-                    properties[actual_prop_name] = {
-                        "people": [
-                            {"object": "user", "id": str(user_id)}
-                            for user_id in value
-                            if user_id
-                        ]
-                    }
-                # Single assignee
-                elif value:
-                    properties[actual_prop_name] = {
-                        "people": [{"object": "user", "id": str(value)}]
-                    }
-            # Add more property types as needed
+            prop_dict = self._convert_property_value(prop_type, value, actual_prop_name)
+            if prop_dict:
+                properties.update(prop_dict)
 
         return properties
 
@@ -449,6 +476,34 @@ class MarkdownImportService(GenericService):
             else:
                 self.logger.warning(
                     f"User not found in workspace | assignee={assignee_value}"
+                )
+                return None
+
+    def _resolve_project_to_page_id(self, project_value: Any) -> str | list[str] | None:
+        """Resolve project name to Notion page ID(s)."""
+        if not project_value:
+            return None
+
+        if isinstance(project_value, list):
+            # Multiple projects
+            page_ids = []
+            for project in project_value:
+                page = self.client.find_project_by_name(str(project))
+                if page:
+                    page_ids.append(page["id"])
+                else:
+                    self.logger.warning(
+                        f"Project not found in workspace | project={project}"
+                    )
+            return page_ids if page_ids else None
+        else:
+            # Single project
+            page = self.client.find_project_by_name(str(project_value))
+            if page:
+                return page["id"]
+            else:
+                self.logger.warning(
+                    f"Project not found in workspace | project={project_value}"
                 )
                 return None
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -268,3 +268,127 @@ class TestNotionAPIClient:
         # Test lookup with non-existent user
         user = client.get_user_by_name_or_email("Unknown User")
         assert user is None
+
+    @staticmethod
+    @patch("thought.client.NOTION_ACCESS_TOKEN", "mocked_token")
+    @patch("thought.client.NotionClient")
+    def test_search_pages(mock_notion_client):
+        """
+        Test searching for pages and databases in the workspace
+        """
+        # Setup mock
+        mock_client_instance = MagicMock()
+        mock_notion_client.return_value = mock_client_instance
+        mock_client_instance.search.return_value = {
+            "results": [
+                {
+                    "id": "page1",
+                    "object": "page",
+                    "properties": {
+                        "title": {
+                            "type": "title",
+                            "title": [
+                                {"type": "text", "text": {"content": "Project Alpha"}}
+                            ],
+                        }
+                    },
+                },
+                {
+                    "id": "db1",
+                    "object": "database",
+                    "properties": {
+                        "title": {
+                            "type": "title",
+                            "title": [
+                                {"type": "text", "text": {"content": "Tasks Database"}}
+                            ],
+                        }
+                    },
+                },
+            ]
+        }
+
+        # Create client and test search
+        client = NotionAPIClient()
+
+        # Test search with query
+        results = client.search_pages(query="Project")
+        expected_result_count = 2
+        assert len(results) == expected_result_count
+        mock_client_instance.search.assert_called_with(query="Project")
+
+        # Test search with filter
+        results = client.search_pages(filter_type="page")
+        mock_client_instance.search.assert_called_with(
+            filter={"value": "page", "property": "object"}
+        )
+
+        # Test search with both query and filter
+        results = client.search_pages(query="Tasks", filter_type="database")
+        mock_client_instance.search.assert_called_with(
+            query="Tasks", filter={"value": "database", "property": "object"}
+        )
+
+    @staticmethod
+    @patch("thought.client.NOTION_ACCESS_TOKEN", "mocked_token")
+    @patch("thought.client.NotionClient")
+    def test_find_project_by_name(mock_notion_client):
+        """
+        Test finding a project by name
+        """
+        # Setup mock
+        mock_client_instance = MagicMock()
+        mock_notion_client.return_value = mock_client_instance
+        mock_client_instance.search.return_value = {
+            "results": [
+                {
+                    "id": "proj1",
+                    "object": "page",
+                    "properties": {
+                        "Title": {
+                            "type": "title",
+                            "title": [
+                                {
+                                    "type": "text",
+                                    "text": {"content": "Website Redesign"},
+                                }
+                            ],
+                        }
+                    },
+                },
+                {
+                    "id": "proj2",
+                    "object": "page",
+                    "properties": {
+                        "Name": {
+                            "type": "title",
+                            "title": [
+                                {"type": "text", "text": {"content": "Mobile App"}}
+                            ],
+                        }
+                    },
+                },
+            ]
+        }
+
+        # Create client and test project lookup
+        client = NotionAPIClient()
+
+        # Test exact match
+        project = client.find_project_by_name("Website Redesign")
+        assert project is not None
+        assert project["id"] == "proj1"
+
+        # Test case-insensitive match
+        project = client.find_project_by_name("WEBSITE REDESIGN")
+        assert project is not None
+        assert project["id"] == "proj1"
+
+        # Test partial match
+        project = client.find_project_by_name("Mobile")
+        assert project is not None
+        assert project["id"] == "proj2"
+
+        # Test non-existent project
+        project = client.find_project_by_name("Unknown Project")
+        assert project is None

--- a/tests/test_markdown_import.py
+++ b/tests/test_markdown_import.py
@@ -833,3 +833,150 @@ class TestMarkdownImportServiceLogging:
 
         # Should return empty list since all users not found
         assert result is None or result == []
+
+    def test_project_resolution(self, import_service):
+        """Test that project names are resolved to page IDs."""
+        # Mock find_project_by_name to return a project
+        import_service.client.find_project_by_name.return_value = {
+            "id": "proj-123",
+            "object": "page",
+            "properties": {
+                "Title": {
+                    "type": "title",
+                    "title": [
+                        {"type": "text", "text": {"content": "Website Redesign"}}
+                    ],
+                }
+            },
+        }
+
+        # Test single project resolution
+        result = import_service._resolve_project_to_page_id("Website Redesign")
+        assert result == "proj-123"
+        import_service.client.find_project_by_name.assert_called_with(
+            "Website Redesign"
+        )
+
+        # Test multiple projects resolution
+        import_service.client.find_project_by_name.side_effect = [
+            {"id": "proj-1", "object": "page"},
+            {"id": "proj-2", "object": "page"},
+        ]
+
+        result = import_service._resolve_project_to_page_id(["Project A", "Project B"])
+        assert result == ["proj-1", "proj-2"]
+
+        # Test project not found - reset side_effect and use return_value
+        import_service.client.find_project_by_name.side_effect = None
+        import_service.client.find_project_by_name.return_value = None
+        result = import_service._resolve_project_to_page_id("Unknown Project")
+        assert result is None
+
+    def test_relation_property_conversion(self, import_service, sample_parsed_markdown):
+        """Test that relation properties are correctly converted."""
+        sample_parsed_markdown.frontmatter = {
+            "title": "Test Task",
+            "project": "Website Redesign",
+        }
+
+        # Mock database with relation property
+        import_service.client.client.databases.retrieve = MagicMock(
+            return_value={
+                "properties": {
+                    "Title": {"type": "title"},
+                    "Project": {"type": "relation"},
+                }
+            }
+        )
+
+        # Mock project resolution
+        import_service.client.find_project_by_name.return_value = {
+            "id": "proj-123",
+            "object": "page",
+        }
+
+        import_service.client.client.pages.create = MagicMock(
+            return_value={"id": "new-page-123"}
+        )
+
+        import_service._create_page("db-123", sample_parsed_markdown)
+
+        # Verify relation property was set correctly
+        call_args = import_service.client.client.pages.create.call_args
+        properties = call_args[1]["properties"]
+
+        assert "Title" in properties
+        assert "Project" in properties
+        assert properties["Project"]["relation"] == [{"id": "proj-123"}]
+
+    def test_multiple_projects_relation(self, import_service, sample_parsed_markdown):
+        """Test handling multiple projects in a relation field."""
+        sample_parsed_markdown.frontmatter = {
+            "title": "Multi-Project Task",
+            "projects": ["Project Alpha", "Project Beta"],
+        }
+
+        # Mock database with relation property
+        import_service.client.client.databases.retrieve = MagicMock(
+            return_value={
+                "properties": {
+                    "Title": {"type": "title"},
+                    "Projects": {"type": "relation"},
+                }
+            }
+        )
+
+        # Mock project resolution for multiple projects
+        import_service.client.find_project_by_name.side_effect = [
+            {"id": "proj-alpha", "object": "page"},
+            {"id": "proj-beta", "object": "page"},
+        ]
+
+        import_service.client.client.pages.create = MagicMock(
+            return_value={"id": "new-page-123"}
+        )
+
+        import_service._create_page("db-123", sample_parsed_markdown)
+
+        # Verify relation property was set correctly with multiple projects
+        call_args = import_service.client.client.pages.create.call_args
+        properties = call_args[1]["properties"]
+
+        assert "Projects" in properties
+        assert properties["Projects"]["relation"] == [
+            {"id": "proj-alpha"},
+            {"id": "proj-beta"},
+        ]
+
+    def test_project_not_found_skipped(self, import_service, sample_parsed_markdown):
+        """Test that properties are skipped when project is not found."""
+        sample_parsed_markdown.frontmatter = {
+            "title": "Task with Missing Project",
+            "project": "Non-Existent Project",
+        }
+
+        # Mock database with relation property
+        import_service.client.client.databases.retrieve = MagicMock(
+            return_value={
+                "properties": {
+                    "Title": {"type": "title"},
+                    "Project": {"type": "relation"},
+                }
+            }
+        )
+
+        # Mock project not found
+        import_service.client.find_project_by_name.return_value = None
+
+        import_service.client.client.pages.create = MagicMock(
+            return_value={"id": "new-page-123"}
+        )
+
+        import_service._create_page("db-123", sample_parsed_markdown)
+
+        # Verify project property was skipped
+        call_args = import_service.client.client.pages.create.call_args
+        properties = call_args[1]["properties"]
+
+        assert "Title" in properties
+        assert "Project" not in properties  # Should be skipped since project not found


### PR DESCRIPTION
- Add automatic resolution of project names to Notion relation IDs during Markdown import, supporting single and multiple projects.
- Implement lookup for user assignments by name or email when mapping frontmatter to Notion "people" fields.
- Update property conversion logic for relation fields to link imported items with related projects.
- Extend docs and README with explanations and usage examples for project linking and user assignment.
- Add comprehensive tests for project relation resolution and import edge cases.
